### PR TITLE
Change page name trimming to not rely on slash

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -31,7 +31,7 @@ func Generate() (map[string]*template.Template, error) {
 	}
 
 	for _, pagePath := range pages {
-		name := strings.TrimPrefix(pagePath, pagesPath+"/")
+		name := pagePath[len(pagesPath) + 1:]
 		t := template.New(name)
 
 		t.Funcs(template.FuncMap{


### PR DESCRIPTION
Previously this was hard coded to rely on forward slash to properly trim the page path string. This didn't work on windows because the page path was using forward slash in the path name.

We instead can just rely on string slicing to trim the string based on an index.