### PR TITLE
redirect to login on group invite

### DIFF
--- a/ui/views/pages/event/details.html
+++ b/ui/views/pages/event/details.html
@@ -126,7 +126,7 @@
 
                             {{if eq $r.UserId $.User.Id}}
                             <span>
-                             (me)
+                                <strong>(me)</strong>
                             </span>
                             {{end}}
                         </div>


### PR DESCRIPTION
Its possible a user who is not currently logged in receives a group invite link. In this situation, they are required to go back to the index page, log in, then go back to the invite link to join the group. This flow is a bit too much, so I made a change to have the group invite link redirect you to the login page if you are logged out, then redirect you back to the invite link to add you to the group. 